### PR TITLE
@uselesslypingme mention game

### DIFF
--- a/Yamamura.py
+++ b/Yamamura.py
@@ -411,6 +411,10 @@ try:
             if msg.author.bot:
                 return
 
+            game_role = role("uselesslypingme")
+            if game_role in msg.role_mentions and not game_role in msg.author.roles:
+                await msg.author.add_roles(game_role)
+
             # check if the message is sent by a person who is composing
             try:
                 ind = composing.index(msg.author.name)


### PR DESCRIPTION
Users who mention the "uselesslypingme" role get the role.
The idea is that once you "troll" the other people with the role, you join the list of people to be "trolled" by the next user that mentions the role.